### PR TITLE
Wait for hCaptcha onLoad

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,9 @@ const React = require('react');
 const CaptchaScript = (cb) => { // Create script to intialize hCaptcha tool - hCaptcha
     let script = document.createElement("script")
 
-    script.src = "https://hcaptcha.com/1/api.js?render=explicit"
+    window.hcaptchaOnLoad = cb;
+    script.src = "https://hcaptcha.com/1/api.js?render=explicit&onload=hcaptchaOnLoad";
     script.async = true
-
-    script.addEventListener('load', cb, true)
 
     return script;
 }


### PR DESCRIPTION
The react-hcaptcha plugin is using the script event listener `load` to render the captcha, instead it should be using the `onload` callback supplied by the hcaptcha api. 

When the script tag finishes loading, the hcaptcha api is availble in the window, however it has not finished running its own initialization steps at this point. The `onload` callback the api provides is meant to address this issue.

Issue https://github.com/hCaptcha/react-hcaptcha/issues/6