### PR TITLE
Reset Then Remove

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A React library for hCaptcha",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,9 @@ class HCaptcha extends React.Component {
     componentWillUnmount() { //If captcha gets removed for timeout or error check to make sure iframe is also removed - hCaptcha
         if(typeof hcaptcha === 'undefined') return
         if (this._removed === false) this.removeFrame()
+
+        // Reset any stored variables / timers when unmounting
+        hcaptcha.reset(this._id)
     }
 
     onsubmitCaptcha (event) {


### PR DESCRIPTION
A small fix to reset the current captcha before removing the iframe from the dom. This prevents any stored variables or timers from being called when the challenge iframe is no longer available.