### PR TITLE
Add support for 'id' prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class HCaptcha extends React.Component {
       this.state = {
         isApiReady: typeof hcaptcha !== 'undefined',
         isRemoved: false,
-        elementId: `hcaptcha-${nanoid()}`,
+        elementId: this.props.id || `hcaptcha-${nanoid()}`,
         captchaId: ''
       }
     }


### PR DESCRIPTION
This PR allows an `id` prop to be passed to the `<HCaptcha />` component which takes precedence over the randomly generated one. This is useful because it allows the component to be utilized in SSR/CSR hybrid apps (like NextJS).

Fixes #31 