### PR TITLE
Add Custom ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ hCaptcha API library and append it to the parent component. This is designed for
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 
 <FormComponent>
-    <HCaptcha 
-      sitekey="your-sitekey" 
+    <HCaptcha
+      sitekey="your-sitekey"
       onVerify={token => handleVerificationSuccess(token)}
     />
 </FormComponent>
@@ -71,6 +71,8 @@ In most real-world implementations, you'll probably be using a form library such
   - Set the tabindex of the widget and popup. When appropriate, this can make navigation of your site more intuitive. This always defaults to 0.
 - languageOverride: String
   - Manually set the language used to render text in the hCaptcha API. See [language codes](https://hcaptcha.com/docs/languages).
+- id: String
+  - Manually set the ID of the hCaptcha component. Make sure each hCaptcha component generated on a single page has it's own unique ID when using this prop.
 
 The component emits events related to verification and expiration. Simply catch these events in the parent component: `onVerify`, `onExpire`, `onError` and handle the events as you choose. The captcha will automatically reset on error, but still emits an error.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In most real-world implementations, you'll probably be using a form library such
 - languageOverride: String
   - Manually set the language used to render text in the hCaptcha API. See [language codes](https://hcaptcha.com/docs/languages).
 - id: String
-  - Manually set the ID of the hCaptcha component. Make sure each hCaptcha component generated on a single page has it's own unique ID when using this prop.
+  - Manually set the ID of the hCaptcha component. Make sure each hCaptcha component generated on a single page has its own unique ID when using this prop.
 
 The component emits events related to verification and expiration. Simply catch these events in the parent component: `onVerify`, `onExpire`, `onError` and handle the events as you choose. The captcha will automatically reset on error, but still emits an error.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,8 +51,12 @@ var HCaptcha = function (_React$Component) {
   function HCaptcha(props) {
     _classCallCheck(this, HCaptcha);
 
-    // API Methods
     var _this = _possibleConstructorReturn(this, (HCaptcha.__proto__ || Object.getPrototypeOf(HCaptcha)).call(this, props));
+
+    var _props$id = props.id,
+        id = _props$id === undefined ? null : _props$id;
+
+    // API Methods
 
     _this.renderCaptcha = _this.renderCaptcha.bind(_this);
     _this.resetCaptcha = _this.resetCaptcha.bind(_this);
@@ -67,7 +71,7 @@ var HCaptcha = function (_React$Component) {
     _this.state = {
       isApiReady: typeof hcaptcha !== 'undefined',
       isRemoved: false,
-      elementId: 'hcaptcha-' + nanoid(),
+      elementId: id || 'hcaptcha-' + nanoid(),
       captchaId: ''
     };
     return _this;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A React library for hCaptcha",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ const CaptchaScript = (cb, hl) => {
 class HCaptcha extends React.Component {
     constructor (props) {
       super(props);
+      const { id=null } = props;
 
       // API Methods
       this.renderCaptcha = this.renderCaptcha.bind(this);
@@ -51,7 +52,7 @@ class HCaptcha extends React.Component {
       this.state = {
         isApiReady: typeof hcaptcha !== 'undefined',
         isRemoved: false,
-        elementId: `hcaptcha-${nanoid()}`,
+        elementId: id || `hcaptcha-${nanoid()}`,
         captchaId: ''
       }
     }


### PR DESCRIPTION
Recent issues with `SSR` have led to different solutions to rendering the captcha due to it's use of ID generation. This PR provides the ability to set a custom `ID` in order to keep the `SSR ID` and `Client ID` matched. 

Issue https://github.com/hCaptcha/react-hcaptcha/issues/28
Issue https://github.com/hCaptcha/react-hcaptcha/issues/31