### PR TITLE
Fix - Wait for setState To Read New State

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,13 +132,15 @@ class HCaptcha extends React.Component {
 
       if (!isApiReady || isRemoved) return
 
-      this.setState({ isRemoved: true });
-      hcaptcha.remove(captchaId);
+      this.setState({ isRemoved: true }, () => {
+        hcaptcha.remove(captchaId);
+      });
     }
 
     handleOnLoad () {
-      this.setState({ isApiReady: true });
-      this.renderCaptcha();
+      this.setState({ isApiReady: true }, () => {
+        this.renderCaptcha();
+      });
     }
 
     handleSubmit (event) {


### PR DESCRIPTION
The Problem is that ```setState``` does not always immediately updates the state. This could result in a race condition where the next operation wants to read the new state. By running the command in the ```setState``` callback will fix this problem.
https://reactjs.org/docs/react-component.html#setstate

addresses #38 

