### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ hCaptcha Component Library for ReactJS.
 
 [hCaptcha](https://www.hcaptcha.com) is a drop-replacement for reCAPTCHA that protects user privacy, rewards websites, and helps companies get their data labeled.
 
-Sign up at [hCaptcha](https://wwww.hcaptcha.com) to get your sitekey today. **You need a sitekey to use this captcha solution.**
+Sign up at [hCaptcha](https://www.hcaptcha.com) to get your sitekey today. **You need a sitekey to use this captcha solution.**
 
 ## Installation
 


### PR DESCRIPTION
The URL in the README contains four "wwww", while there should only be three of them