### PR TITLE
Setup query parameters for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ In these instances, you'll most likely want to use `ref` to handle the callbacks
 |`id`|String|No|`random id`|Manually set the ID of the hCaptcha component. Make sure each hCaptcha component generated on a single page has its own unique ID when using this prop.|
 |`apihost`|String|No|`-`|See enterprise docs.|
 |`assethost`|String|No|`-`|See enterprise docs.|
+|`endpoint`|String|No|`-`|See enterprise docs.|
 |`imghost`|String|No|`-`|See enterprise docs.|
 |`reportapi`|String|No|`-`|See enterprise docs.|
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ In these instances, you'll most likely want to use `ref` to handle the callbacks
 |`endpoint`|String|No|`-`|See enterprise docs.|
 |`imghost`|String|No|`-`|See enterprise docs.|
 |`reportapi`|String|No|`-`|See enterprise docs.|
+|`sentry`|String|No|`-`|See enterprise docs.|
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ In these instances, you'll most likely want to use `ref` to handle the callbacks
 |`languageOverride`|String (ISO 639-2 code)|No|`auto`|hCaptcha auto-detects language via the user's browser. This overrides that to set a default UI language. See [language codes](https://hcaptcha.com/docs/languages).|
 |`reCaptchaCompat`|Boolean|No|`true`|Disable drop-in replacement for reCAPTCHA with `false` to prevent hCaptcha from injecting into `window.grecaptcha`.|
 |`id`|String|No|`random id`|Manually set the ID of the hCaptcha component. Make sure each hCaptcha component generated on a single page has its own unique ID when using this prop.|
+|`apihost`|String|No|`-`|See enterprise docs.|
+|`assethost`|String|No|`-`|See enterprise docs.|
+|`imghost`|String|No|`-`|See enterprise docs.|
+|`reportapi`|String|No|`-`|See enterprise docs.|
 
 ### Events
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
-  "version": "0.3.0-alpha",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class HCaptcha extends React.Component {
     }
 
     componentDidMount () { //Once captcha is mounted intialize hCaptcha - hCaptcha
-      const { apihost, assethost, endpoint, imghost, languageOverride:hl, reCaptchaCompat, reportapi } = this.props;
+      const { apihost, assethost, endpoint, imghost, languageOverride:hl, reCaptchaCompat, reportapi, sentry } = this.props;
       const { isApiReady } = this.state;
 
       if (!isApiReady) {  //Check if hCaptcha has already been loaded, if not create script tag and wait to render captcha
@@ -76,7 +76,8 @@ class HCaptcha extends React.Component {
               hl,
               imghost,
               recaptchacompat: reCaptchaCompat === false? "off" : null,
-              reportapi
+              reportapi,
+              sentry
             });
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class HCaptcha extends React.Component {
     }
 
     componentDidMount () { //Once captcha is mounted intialize hCaptcha - hCaptcha
-      const { languageOverride:hl, reCaptchaCompat, apihost, assethost, imghost, reportapi } = this.props;
+      const { apihost, assethost, endpoint, imghost, languageOverride:hl, reCaptchaCompat, reportapi } = this.props;
       const { isApiReady } = this.state;
 
       if (!isApiReady) {  //Check if hCaptcha has already been loaded, if not create script tag and wait to render captcha
@@ -70,9 +70,10 @@ class HCaptcha extends React.Component {
             // Only create the script tag once, use a global variable to track
             captchaScriptCreated = true;
             CaptchaScript({
-              hl,
               apihost,
               assethost,
+              endpoint,
+              hl,
               imghost,
               recaptchacompat: reCaptchaCompat === false? "off" : null,
               reportapi

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,11 @@
+function generateQuery(params) {
+    return Object.entries(params)
+        .filter(([key, value]) => value || value === false)
+        .map(([key, value]) => {
+            return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+        }).join("&");
+};
+
+module.exports = {
+    generateQuery
+};

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -239,5 +239,15 @@ describe("hCaptcha", () => {
             const script = document.querySelector("head > script");
             expect(script.src).not.toEqual(expect.stringContaining("recaptchacompat"));
         });
+
+        it("sentry should be found when prop is set", () => {
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    sentry={true}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining("sentry=true"));
+        });
     });
 });

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -141,8 +141,6 @@ describe("hCaptcha", () => {
         });
 
         it("validate src without", () => {
-            const ExpectHost = "https://test.com";
-
             instance = ReactTestUtils.renderIntoDocument(<HCaptcha
                     sitekey={TEST_PROPS.sitekey}
                 />);
@@ -201,8 +199,6 @@ describe("hCaptcha", () => {
         });
 
         it("hl should be found when prop languageOverride is set", () => {
-            const ExpectHost = "https://test.com";
-
             instance = ReactTestUtils.renderIntoDocument(<HCaptcha
                     languageOverride="fr"
                     sitekey={TEST_PROPS.sitekey}
@@ -213,8 +209,6 @@ describe("hCaptcha", () => {
         });
 
         it("reCaptchaCompat should be found when prop is set to false", () => {
-            const ExpectHost = "https://test.com";
-
             instance = ReactTestUtils.renderIntoDocument(<HCaptcha
                     reCaptchaCompat={false}
                     sitekey={TEST_PROPS.sitekey}
@@ -225,8 +219,6 @@ describe("hCaptcha", () => {
         });
 
         it("reCaptchaCompat should not be found when prop is set to anything except false", () => {
-            const ExpectHost = "https://test.com";
-
             instance = ReactTestUtils.renderIntoDocument(<HCaptcha
                     reCaptchaCompat={true}
                     sitekey={TEST_PROPS.sitekey}

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -174,6 +174,18 @@ describe("hCaptcha", () => {
             expect(script.src).toEqual(expect.stringContaining(`assethost=${encodeURIComponent(ExpectHost)}`));
         });
 
+        it("endpoint should be found when prop is set", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    endpoint={ExpectHost}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining(`endpoint=${encodeURIComponent(ExpectHost)}`));
+        });
+
         it("imghost should be found when prop is set", () => {
             const ExpectHost = "https://test.com";
 

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -1,18 +1,18 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-dom/test-utils';
-import HCaptcha from '../src/index';
-import {getMockedHcaptcha, MOCK_EKEY, MOCK_TOKEN, MOCK_WIDGET_ID} from './hcaptcha.mock';
+import React from "react";
+import ReactDOM from "react-dom";
+import ReactTestUtils, { act } from "react-dom/test-utils";
+import HCaptcha from "../src/index";
+import {getMockedHcaptcha, MOCK_EKEY, MOCK_TOKEN, MOCK_WIDGET_ID} from "./hcaptcha.mock";
 
 
 const TEST_PROPS = {
-    sitekey: '10000000-ffff-ffff-ffff-000000000001',
-    theme: 'light',
-    size: 'invisible',
+    sitekey: "10000000-ffff-ffff-ffff-000000000001",
+    theme: "light",
+    size: "invisible",
     tabindex: 0,
 };
 
-describe('hCaptcha', () => {
+describe("hCaptcha", () => {
     let instance;
     let mockFns;
 
@@ -38,39 +38,39 @@ describe('hCaptcha', () => {
         );
     });
 
-    it('renders into a div', () => {
+    it("renders into a div", () => {
         expect(ReactDOM.findDOMNode(instance).nodeName).toBe("DIV");
     });
 
-    it('has functions', () => {
-        expect(typeof instance.execute).toBe('function');
-        expect(typeof instance.resetCaptcha).toBe('function');
+    it("has functions", () => {
+        expect(typeof instance.execute).toBe("function");
+        expect(typeof instance.resetCaptcha).toBe("function");
         expect(instance.execute).toBeDefined();
         expect(instance.resetCaptcha).toBeDefined();
     });
 
-    it('can execute', () => {
+    it("can execute", () => {
         expect(window.hcaptcha.execute.mock.calls.length).toBe(0);
         instance.execute();
         expect(window.hcaptcha.execute.mock.calls.length).toBe(1);
         expect(window.hcaptcha.execute.mock.calls[0][0]).toBe(MOCK_WIDGET_ID);
     });
 
-    it('can reset', () => {
+    it("can reset", () => {
         expect(window.hcaptcha.reset.mock.calls.length).toBe(0);
         instance.resetCaptcha();
         expect(window.hcaptcha.reset.mock.calls.length).toBe(1);
         expect(window.hcaptcha.reset.mock.calls[0][0]).toBe(MOCK_WIDGET_ID);
     });
 
-    it('can remove', () => {
+    it("can remove", () => {
         expect(window.hcaptcha.remove.mock.calls.length).toBe(0);
         instance.removeCaptcha();
         expect(window.hcaptcha.remove.mock.calls.length).toBe(1);
         expect(window.hcaptcha.remove.mock.calls[0][0]).toBe(MOCK_WIDGET_ID);
     });
 
-    it('emits verify with token and eKey', () => {
+    it("emits verify with token and eKey", () => {
         expect(mockFns.onVerify.mock.calls.length).toBe(0);
         instance.handleSubmit();
         expect(mockFns.onVerify.mock.calls.length).toBe(1);
@@ -78,23 +78,23 @@ describe('hCaptcha', () => {
         expect(mockFns.onVerify.mock.calls[0][1]).toBe(MOCK_EKEY);
     });
 
-    it('emits error and calls reset', () => {
+    it("emits error and calls reset", () => {
         expect(mockFns.onError.mock.calls.length).toBe(0);
-        const error = 'invalid-input-response';
+        const error = "invalid-input-response";
         instance.handleError(error);
         expect(mockFns.onError.mock.calls.length).toBe(1);
         expect(mockFns.onError.mock.calls[0][0]).toBe(error);
         expect(window.hcaptcha.reset.mock.calls.length).toBe(1);
     });
 
-    it('emits expire and calls reset', () => {
+    it("emits expire and calls reset", () => {
         expect(mockFns.onExpire.mock.calls.length).toBe(0);
         instance.handleExpire();
         expect(mockFns.onExpire.mock.calls.length).toBe(1);
         expect(window.hcaptcha.reset.mock.calls.length).toBe(1);
     });
 
-    it('el renders after api loads and a widget id is set', () => {
+    it("el renders after api loads and a widget id is set", () => {
         expect(instance.state.captchaId).toBe(MOCK_WIDGET_ID);
         expect(window.hcaptcha.render.mock.calls.length).toBe(1);
         expect(window.hcaptcha.render.mock.calls[0][1]).toMatchObject({
@@ -105,7 +105,7 @@ describe('hCaptcha', () => {
         });
     });
 
-    it('should set id if id prop is passed', () => {
+    it("should set id if id prop is passed", () => {
         instance = ReactTestUtils.renderIntoDocument(
             <HCaptcha
                 sitekey={TEST_PROPS.sitekey}
@@ -116,8 +116,8 @@ describe('hCaptcha', () => {
         expect(node.getAttribute("id")).toBe("test-id-1");
     });
 
-    it('should not set id if no id prop is passed', () => {
-        process.env.NODE_ENV = 'development';
+    it("should not set id if no id prop is passed", () => {
+        process.env.NODE_ENV = "development";
         instance = ReactTestUtils.renderIntoDocument(
             <HCaptcha
                 sitekey={TEST_PROPS.sitekey}
@@ -127,4 +127,113 @@ describe('hCaptcha', () => {
         expect(node.getAttribute("id")).toBe(null);
     });
 
+    describe("Query parameter", () => {
+
+        beforeEach(() => {
+            // Setup hCaptcha as undefined to load script
+            window.hcaptcha = undefined;
+        });
+
+        afterEach(() => {
+            // Clean up created script tag
+            document.querySelectorAll("head > script")
+              .forEach(script => document.head.removeChild(script));
+        });
+
+        it("validate src without", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual("https://hcaptcha.com/1/api.js?render=explicit&onload=hcaptchaOnLoad");
+        });
+
+        it("apihost should change script src, but not be added as query", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    apihost={ExpectHost}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining(ExpectHost));
+            expect(script.src).not.toEqual(expect.stringContaining(`apihost=${encodeURIComponent(ExpectHost)}`));
+        });
+
+        it("assethost should be found when prop is set", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    assethost={ExpectHost}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining(`assethost=${encodeURIComponent(ExpectHost)}`));
+        });
+
+        it("imghost should be found when prop is set", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    imghost={ExpectHost}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining(`imghost=${encodeURIComponent(ExpectHost)}`));
+        });
+
+        it("reportapi should be found when prop is set", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    reportapi={ExpectHost}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining(`reportapi=${encodeURIComponent(ExpectHost)}`));
+        });
+
+        it("hl should be found when prop languageOverride is set", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    languageOverride="fr"
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining("hl=fr"));
+        });
+
+        it("reCaptchaCompat should be found when prop is set to false", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    reCaptchaCompat={false}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).toEqual(expect.stringContaining("recaptchacompat=off"));
+        });
+
+        it("reCaptchaCompat should not be found when prop is set to anything except false", () => {
+            const ExpectHost = "https://test.com";
+
+            instance = ReactTestUtils.renderIntoDocument(<HCaptcha
+                    reCaptchaCompat={true}
+                    sitekey={TEST_PROPS.sitekey}
+                />);
+
+            const script = document.querySelector("head > script");
+            expect(script.src).not.toEqual(expect.stringContaining("recaptchacompat"));
+        });
+    });
 });

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -158,8 +158,8 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining(ExpectHost));
-            expect(script.src).not.toEqual(expect.stringContaining(`apihost=${encodeURIComponent(ExpectHost)}`));
+            expect(script.src).toContain(ExpectHost);
+            expect(script.src).not.toContain(`apihost=${encodeURIComponent(ExpectHost)}`);
         });
 
         it("assethost should be found when prop is set", () => {
@@ -171,7 +171,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining(`assethost=${encodeURIComponent(ExpectHost)}`));
+            expect(script.src).toContain(`assethost=${encodeURIComponent(ExpectHost)}`);
         });
 
         it("endpoint should be found when prop is set", () => {
@@ -183,7 +183,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining(`endpoint=${encodeURIComponent(ExpectHost)}`));
+            expect(script.src).toContain(`endpoint=${encodeURIComponent(ExpectHost)}`);
         });
 
         it("imghost should be found when prop is set", () => {
@@ -195,7 +195,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining(`imghost=${encodeURIComponent(ExpectHost)}`));
+            expect(script.src).toContain(`imghost=${encodeURIComponent(ExpectHost)}`);
         });
 
         it("reportapi should be found when prop is set", () => {
@@ -207,7 +207,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining(`reportapi=${encodeURIComponent(ExpectHost)}`));
+            expect(script.src).toContain(`reportapi=${encodeURIComponent(ExpectHost)}`);
         });
 
         it("hl should be found when prop languageOverride is set", () => {
@@ -217,7 +217,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining("hl=fr"));
+            expect(script.src).toContain("hl=fr");
         });
 
         it("reCaptchaCompat should be found when prop is set to false", () => {
@@ -227,7 +227,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining("recaptchacompat=off"));
+            expect(script.src).toContain("recaptchacompat=off");
         });
 
         it("reCaptchaCompat should not be found when prop is set to anything except false", () => {
@@ -237,7 +237,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).not.toEqual(expect.stringContaining("recaptchacompat"));
+            expect(script.src).not.toContain("recaptchacompat");
         });
 
         it("sentry should be found when prop is set", () => {
@@ -247,7 +247,7 @@ describe("hCaptcha", () => {
                 />);
 
             const script = document.querySelector("head > script");
-            expect(script.src).toEqual(expect.stringContaining("sentry=true"));
+            expect(script.src).toContain("sentry=true");
         });
     });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,44 @@
+import { generateQuery } from "../src/utils.js";
+
+describe("Encode query", () => {
+
+    it("Property foo to equal bar as string foo=bar:", () => {
+        const params = {
+            foo: "bar"
+        };
+        expect(generateQuery(params)).toBe("foo=bar");
+    });
+
+    it("Spaces to be encoded with %20", () => {
+        const params = {
+            foo: "bar baz bah"
+        };
+        expect(generateQuery(params)).toBe("foo=bar%20baz%20bah");
+    });
+
+    it("Chain multiple parameters", () => {
+        const params = {
+            foo: "bar",
+            baz: true
+        };
+        expect(generateQuery(params)).toBe("foo=bar&baz=true");
+    });
+
+    it("false should be a valid query parameter", () => {
+        const params = {
+            foo: false
+        };
+        expect(generateQuery(params)).toBe("foo=false");
+    });
+
+    it("Null, undefined, and empty string values should be removed", () => {
+        const params = {
+            foo: "",
+            bar: null,
+            baz: undefined,
+            bah: true
+        };
+        expect(generateQuery(params)).toBe("bah=true");
+    });
+
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -24,7 +24,7 @@ describe("Encode query", () => {
         expect(generateQuery(params)).toBe("foo=bar&baz=true");
     });
 
-    it("false should be a valid query parameter", () => {
+    it("false should be a valid query value", () => {
         const params = {
             foo: false
         };


### PR DESCRIPTION
Adds query parameter support for the hCaptcha API, along with tests for new and previous set query parameters.

Closes https://github.com/hCaptcha/react-hcaptcha/issues/71