### PR TITLE
Call execute after load if execute was called before ready

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,10 @@ class HCaptcha extends React.Component {
 
         // render captcha
         this.renderCaptcha();
+
+        if (this.executeOnLoad) {
+          this.execute();
+        }
       });
     }
 
@@ -199,7 +203,14 @@ class HCaptcha extends React.Component {
     execute () {
       const { isApiReady, isRemoved, captchaId } = this.state;
 
-      if (!isApiReady || isRemoved) return
+      if (!isApiReady) {
+        this.executeOnLoad = true;
+        return;
+      }
+
+      if (isRemoved) {
+        return;
+      }
 
       hcaptcha.execute(captchaId)
     }

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -140,6 +140,31 @@ describe("hCaptcha", () => {
         expect(node.getAttribute("id")).toBe(null);
     });
 
+    it("correctly executes even if execute() was called before load", () => {
+        const hcaptchaGlobal = window.hcaptcha;
+        delete window.hcaptcha;
+
+        instance = ReactTestUtils.renderIntoDocument(
+            <HCaptcha
+                sitekey={TEST_PROPS.sitekey}
+                theme={TEST_PROPS.theme}
+                size={TEST_PROPS.size}
+                tabindex={TEST_PROPS.tabindex}
+                onChange={mockFns.onChange}
+                onVerify={mockFns.onVerify}
+                onError={mockFns.onError}
+                onExpire={mockFns.onExpire}
+                onLoad={mockFns.onLoad}
+            />,
+        );
+
+        instance.execute();
+        expect(hcaptchaGlobal.execute.mock.calls.length).toBe(0);
+        window.hcaptcha = hcaptchaGlobal;
+        instance.handleOnLoad();
+        expect(hcaptchaGlobal.execute.mock.calls.length).toBe(1);
+    })
+
     describe("Query parameter", () => {
 
         beforeEach(() => {


### PR DESCRIPTION
The component has a race condition where if `execute()` is called before the API is loaded, `execute` will just fail silently. The fix is to add a flag which we check on load, and calls execute again once the API is loaded if the parent had previously called it. The caller could implement the same fix we are implementing here but it is easier if the component just took care of it automatically. This PR is not compatible with https://github.com/hCaptcha/react-hcaptcha/pull/91