### PR TITLE
Fix onLoad race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "types": "types/index.d.ts",
   "main": "dist/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,6 @@ class HCaptcha extends React.Component {
     }
 
     componentDidMount () { //Once captcha is mounted intialize hCaptcha - hCaptcha
-
       const { apihost, assethost, endpoint, host, imghost, languageOverride:hl, reCaptchaCompat, reportapi, sentry, custom } = this.props;
       const { isApiReady } = this.state;
 
@@ -89,7 +88,6 @@ class HCaptcha extends React.Component {
     }
 
     componentWillUnmount() {
-
         const { isApiReady, isRemoved, captchaId } = this.state;
         if(!isApiReady || isRemoved) return
 
@@ -122,7 +120,6 @@ class HCaptcha extends React.Component {
     }
 
     renderCaptcha(onReady) {
-
       const { isApiReady } = this.state;
       if (!isApiReady) return;
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ class HCaptcha extends React.Component {
     }
 
     componentDidMount () { //Once captcha is mounted intialize hCaptcha - hCaptcha
+
       const { apihost, assethost, endpoint, host, imghost, languageOverride:hl, reCaptchaCompat, reportapi, sentry, custom } = this.props;
       const { isApiReady } = this.state;
 
@@ -88,6 +89,7 @@ class HCaptcha extends React.Component {
     }
 
     componentWillUnmount() {
+
         const { isApiReady, isRemoved, captchaId } = this.state;
         if(!isApiReady || isRemoved) return
 
@@ -119,7 +121,8 @@ class HCaptcha extends React.Component {
       }
     }
 
-    renderCaptcha() {
+    renderCaptcha(onReady) {
+
       const { isApiReady } = this.state;
       if (!isApiReady) return;
 
@@ -132,7 +135,9 @@ class HCaptcha extends React.Component {
           "callback"            : this.handleSubmit,
         });
 
-      this.setState({ isRemoved: false, captchaId });
+      this.setState({ isRemoved: false, captchaId }, () => {
+        onReady && onReady();
+      });
     }
 
     resetCaptcha() {
@@ -156,12 +161,13 @@ class HCaptcha extends React.Component {
 
     handleOnLoad () {
       this.setState({ isApiReady: true }, () => {
-        // trigger onLoad if it exists
-        const { onLoad } = this.props;
-        if (onLoad) onLoad();
 
-        // render captcha
-        this.renderCaptcha();
+        // render captcha and wait for captcha id
+        this.renderCaptcha(() => {
+            // trigger onLoad if it exists
+            const { onLoad } = this.props;
+            if (onLoad) onLoad();
+        });
       });
     }
 

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -1,7 +1,6 @@
 import React, { useRef } from "react";
 import ReactDOM from "react-dom";
 import ReactTestUtils, { act } from "react-dom/test-utils";
-import waitForExpect from "wait-for-expect";
 import {getMockedHcaptcha, MOCK_EKEY, MOCK_TOKEN, MOCK_WIDGET_ID} from "./hcaptcha.mock";
 
 let HCaptcha;

--- a/tests/hcaptcha.spec.js
+++ b/tests/hcaptcha.spec.js
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useRef } from "react";
 import ReactDOM from "react-dom";
 import ReactTestUtils, { act } from "react-dom/test-utils";
+import waitForExpect from "wait-for-expect";
 import {getMockedHcaptcha, MOCK_EKEY, MOCK_TOKEN, MOCK_WIDGET_ID} from "./hcaptcha.mock";
 
 let HCaptcha;
@@ -176,6 +177,24 @@ describe("hCaptcha", () => {
         const node = ReactDOM.findDOMNode(instance);
         expect(node.getAttribute("id")).toBe(null);
     });
+
+    it("should not set id if no id prop is passed", (done) => {
+
+        const onLoad = jest.fn(() => {
+            expect(instance.state.captchaId).toBe(MOCK_WIDGET_ID);
+            done();
+        });
+
+        instance = ReactTestUtils.renderIntoDocument(
+            <HCaptcha
+                sitekey={TEST_PROPS.sitekey}
+                onLoad={onLoad}
+            />,
+        );
+
+        instance.handleOnLoad();
+    });
+
 
     describe("Query parameter", () => {
 


### PR DESCRIPTION
Calling `hCaptchaRef.current.execute` when `onLoad` callback invokes throws error as hCaptcha client is not setup just yet. The call to render the hCaptcha client takes place right after the `onLoad` callback is called. This PR is meant to fix this issue, and may be related to what this [PR](https://github.com/hCaptcha/react-hcaptcha/pull/97) is trying to solve.