### PR TITLE
Add repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/hCaptcha/react-hcaptcha.git"
-  }
+  },
   "license": "MIT",
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "captcha"
   ],
   "author": "hCaptcha team and contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hCaptcha/react-hcaptcha.git"
+  }
   "license": "MIT",
   "devDependencies": {
     "@babel/cli": "^7.12.10",


### PR DESCRIPTION
Whenever Dependabot updates @hCaptcha/react-hcaptcha it doesn't provide the changelog. npm also doesn't link to the repo.

I _think_ adding this key would fix both of these.