### PR TITLE
add types for `HCaptcha.isReady()`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,6 +46,7 @@ declare class HCaptcha extends React.Component<HCaptchaProps, HCaptchaState> {
   getRespKey(): string;
   getResponse(): string;
   setData(data: object): void;
+  isReady(): boolean;
   execute(opts: { async: true }): Promise<ExecuteResponse>;
   execute(opts?: { async: false }): void;
   execute(opts?: { async: boolean }): Promise<ExecuteResponse> | void;


### PR DESCRIPTION
it's a part of ["API Methods"][1] and a [suggested solution/workaround](https://github.com/hCaptcha/react-hcaptcha/issues/198) for executing captcha on second mount

[1]: https://github.com/hCaptcha/react-hcaptcha/blob/84cad37251fe5976fa94c2681716729e89f5781d/src/index.js#L20-L24