### PR TITLE
fix(types): Re-add typing overloads for the `execute` method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,7 +52,7 @@ declare class HCaptcha extends React.Component<HCaptchaProps, HCaptchaState> {
   isReady(): boolean;
   execute(opts: { async: true, rqdata?: string }): Promise<ExecuteResponse>;
   execute(opts?: { async: false, rqdata?: string }): void;
-  execute(opts: { async: boolean, rqdata?: string }): Promise<ExecuteResponse> | void;
+  execute(opts?: { async?: boolean, rqdata?: string }): Promise<ExecuteResponse> | void;
 }
 
 export = HCaptcha;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,7 +50,9 @@ declare class HCaptcha extends React.Component<HCaptchaProps, HCaptchaState> {
   getResponse(): string;
   setData(data: object): void;
   isReady(): boolean;
-  execute(opts?: { async?: boolean, rqdata?: string }): Promise<ExecuteResponse> | void;
+  execute(opts: { async: true, rqdata?: string }): Promise<ExecuteResponse>;
+  execute(opts?: { async: false, rqdata?: string }): void;
+  execute(opts?: { async: boolean, rqdata?: string }): Promise<ExecuteResponse> | void;
 }
 
 export = HCaptcha;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,7 +52,7 @@ declare class HCaptcha extends React.Component<HCaptchaProps, HCaptchaState> {
   isReady(): boolean;
   execute(opts: { async: true, rqdata?: string }): Promise<ExecuteResponse>;
   execute(opts?: { async: false, rqdata?: string }): void;
-  execute(opts?: { async: boolean, rqdata?: string }): Promise<ExecuteResponse> | void;
+  execute(opts: { async: boolean, rqdata?: string }): Promise<ExecuteResponse> | void;
 }
 
 export = HCaptcha;


### PR DESCRIPTION
In this pull request (https://github.com/hCaptcha/react-hcaptcha/pull/233) it seems some nice overloads were removed. I've adjusted it back to how originally was and added rqdata.