### PR TITLE
feat(package): Bump hCaptcha loader version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
-        "@hcaptcha/loader": "^2.0.0"
+        "@hcaptcha/loader": "^2.0.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.12.1",
@@ -1898,9 +1898,10 @@
       }
     },
     "node_modules/@hcaptcha/loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hcaptcha/loader/-/loader-2.0.0.tgz",
-      "integrity": "sha512-fFQH6ApU/zCCl6Y1bnbsxsp1Er/lKX+qlgljrpWDeFcenpEtoP68hExlKSXECospzKLeSWcr06cbTjlR/x3IJA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/loader/-/loader-2.0.1.tgz",
+      "integrity": "sha512-L36qqdOmv8fL6VBZcH34JUI0/SvC5KPOZ5N/m+5pQAPPhtXXRdU4o9iosZr12hWAM2qf5hC92kmi+XdqxKOEZQ==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "types": "types/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
@@ -60,6 +60,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "@hcaptcha/loader": "^2.0.0"
+    "@hcaptcha/loader": "^2.0.1"
   }
 }


### PR DESCRIPTION
Updates hCaptcha/loader to [Version 2.0.1](https://github.com/hCaptcha/hcaptcha-loader/releases/tag/v2.0.1), adding default value `anonymous` to `script.crossOrigin` for loading the hCaptcha client API across origins.