### PR TITLE
chore: Clean up workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     name: Build & Test
@@ -7,7 +9,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18.x'
       - run: npm ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,10 @@ on:
     branches: [master]
   schedule:
     - cron: '0 20 * * 3'
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
   analyze:
@@ -35,8 +39,9 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+        persist-credentials: false
 
-    - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '18.x'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   release:
     types: [ created ]
+permissions:
+  contents: read
 jobs:
   build:
     name: Build & Test & Publish
@@ -10,7 +12,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
  - .github/workflows/ci.yml: locked workflow permissions to contents: read, disabled checkout credential persistence, and updated actions/setup-node to pinned v4.4.0 to avoid default write-all token exposure and rely on a supported runner.
  - .github/workflows/codeql-analysis.yml: added least-privilege permissions (actions: read, contents: read, security-events: write), disabled checkout credential persistence, and bumped actions/setup-node to pinned v4.4.0.
  - .github/workflows/publish.yml: set contents: read permissions for the release/manual workflow, turned off checkout credential persistence, and upgraded actions/setup-node to pinned v4.4.0 so secrets stay isolated from the GitHub token.