### PR TITLE
fix: Add type module to ESM build output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hcaptcha/react-hcaptcha",
-      "version": "1.17.2",
+      "version": "1.17.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "types": "types/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Description:

- Fixes issue #337
- Adds `{"type":"module"}` to `dist/esm/package.json` so Node.js recognizes ESM files correctly.