### PR TITLE
fix: Hook imports for ESM compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,12 @@ module.exports = {
     // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
     testPathIgnorePatterns: ["/node_modules/", "webpack.config.test.js"],
 
-    testEnvironment: 'jsdom'
+    testEnvironment: 'jsdom',
+
+    // Map .js imports to .jsx files in src/hooks
+    moduleNameMapper: {
+        "^\\./useHCaptcha\\.js$": "./useHCaptcha.jsx",
+        "^\\./Provider\\.js$": "./Provider.jsx",
+        "^\\./Context\\.js$": "./Context.jsx"
+    }
 };

--- a/src/hooks/Provider.jsx
+++ b/src/hooks/Provider.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import HCaptcha from "../index";
-import { HCaptchaContext } from "./Context";
+import HCaptcha from "../index.js";
+import { HCaptchaContext } from "./Context.js";
 
 export const HCaptchaProvider = ({
   sitekey = null,

--- a/src/hooks/index.jsx
+++ b/src/hooks/index.jsx
@@ -1,2 +1,2 @@
-export { useHCaptcha } from "./useHCaptcha";
-export { HCaptchaProvider } from "./Provider";
+export { useHCaptcha } from "./useHCaptcha.js";
+export { HCaptchaProvider } from "./Provider.js";

--- a/src/hooks/useHCaptcha.jsx
+++ b/src/hooks/useHCaptcha.jsx
@@ -1,4 +1,4 @@
 import { useContext } from "react";
 
-import { HCaptchaContext } from "./Context";
+import { HCaptchaContext } from "./Context.js";
 export const useHCaptcha = () => useContext(HCaptchaContext);


### PR DESCRIPTION
## Description

- Refers to issue: https://github.com/hCaptcha/react-hcaptcha/issues/340 as alternative approach for https://github.com/hCaptcha/react-hcaptcha/pull/343


### Changes:
- Renamed `useHCaptcha.tsx` -> `useHCaptcha.jsx` (file had no TypeScript, just wrong extension);
- Added explicit `.js` extensions to all relative imports in hooks;
- Added Jest `moduleNameMapper` to resolve `.js` → `.jsx` during tests;