### PR TITLE
change loader error handling

### DIFF
--- a/lib/__tests__/unit/hcaptcha-loader-error.test.tsx
+++ b/lib/__tests__/unit/hcaptcha-loader-error.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, cleanup, render } from '@testing-library/react';
+
+jest.mock('@hcaptcha/loader', () => ({
+  hCaptchaLoader: jest.fn(),
+}));
+
+const mockHCaptchaLoader = require('@hcaptcha/loader').hCaptchaLoader;
+const HCaptcha = require('../../src/index.js').default;
+
+describe('hCaptcha loader errors', () => {
+  beforeEach(() => {
+    window.hcaptcha = undefined;
+    mockHCaptchaLoader.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('normalizes script load errors', async () => {
+    const onError = jest.fn();
+    mockHCaptchaLoader.mockRejectedValueOnce(new Error('script-error'));
+
+    await act(async () => {
+      render(<HCaptcha sitekey="test-sitekey" onError={onError} />);
+      await Promise.resolve();
+    });
+
+    expect(onError).toHaveBeenCalledWith('script-error');
+  });
+
+  it('reports when initial script error handling throws', async () => {
+    const onError = jest.fn()
+      .mockImplementationOnce(() => { throw new Error('error-handler-failed'); });
+    mockHCaptchaLoader.mockRejectedValueOnce(new Error('script-error'));
+
+    await act(async () => {
+      render(<HCaptcha sitekey="test-sitekey" onError={onError} />);
+      await Promise.resolve();
+    });
+
+    expect(onError.mock.calls).toEqual([
+      ['script-error'],
+      ['script-load-error-other'],
+    ]);
+  });
+});

--- a/lib/__tests__/unit/hcaptcha.test.tsx
+++ b/lib/__tests__/unit/hcaptcha.test.tsx
@@ -346,31 +346,6 @@ describe("hCaptcha", () => {
             jest.restoreAllMocks();
         });
 
-        // TODO: This test needs to be updated to work with @hcaptcha/loader
-        // The error callback is now triggered by loader rejection, not script onerror
-        it.skip("emits error when script is failed", async () => {
-            const onError = jest.fn();
-
-            // Make hCaptchaLoader reject to simulate script loading failure
-            const loader = require('@hcaptcha/loader');
-            loader.hCaptchaLoader.mockImplementationOnce(() => {
-                return Promise.reject(new Error("script-error"));
-            });
-
-            await act(async () => {
-              render(<HCaptcha
-                onError={onError}
-                sitekey={TEST_PROPS.sitekey}
-                sentry={false}
-              />);
-              // Wait for promise rejection to be handled
-              await new Promise(resolve => setTimeout(resolve, 0));
-            });
-
-            expect(onError.mock.calls.length).toBe(1);
-            expect((onError.mock.calls[0][0] as Error).message).toEqual("script-error");
-        });
-
         it("validate src without", () => {
             render(<HCaptcha
               sitekey={TEST_PROPS.sitekey}

--- a/lib/src/component/HCaptcha.jsx
+++ b/lib/src/component/HCaptcha.jsx
@@ -170,9 +170,16 @@ export class HCaptcha extends React.Component {
         uj: userJourneys !== undefined ? userJourneys : false,
       };
 
-      hCaptchaLoader(mountParams)
-          .then(this.handleOnLoad, this.handleError)
-          .catch(this.handleError);
+      hCaptchaLoader(mountParams).then(
+        this.handleOnLoad,
+        () => {
+          try {
+            this.handleError('script-error');
+          } catch {
+            this.handleError('script-load-error-other');
+          }
+        }
+      );
 
       this.apiScriptRequested = true;
     }


### PR DESCRIPTION
## Summary

- Normalize SDK script-load failures to `script-error`.
- Report `script-load-error-other` if the initial `onError` handler throws.
- Prevent loader rejection values from ever leaking through `onError`.

## Motivation

- Existing promise chaining routed exceptions thrown by initial error handling back through `handleError`.
- `hcaptcha-loader` has more error states, but the relevant error is that the script couldn't be loaded.

## Testing

Used 'manual' Chromium test with unreachable `scriptSource` to confirm:
  - Normal handler: `script-error`
  - Throwing handler: `script-error`, then `script-load-error-other`
  - Initial request plus two retries failed as expected.