### PR TITLE
fix(state): isApiReady state update race condition

### DIFF
--- a/lib/src/component/HCaptcha.jsx
+++ b/lib/src/component/HCaptcha.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { flushSync } from 'react-dom';
 import { hCaptchaLoader } from '@hcaptcha/loader';
 
 import { getFrame, getMountElement } from '../utils.js';
@@ -252,20 +253,21 @@ export class HCaptcha extends React.Component {
     }
 
     handleOnLoad () {
-      this.setState({ isApiReady: true }, () => {
-          const element = getMountElement(this.props.scriptLocation);
-          const frame = getFrame(element);
+      const element = getMountElement(this.props.scriptLocation);
+      const frame = getFrame(element);
 
-          this._hcaptcha = frame.window.hcaptcha;
+      this._hcaptcha = frame.window.hcaptcha;
 
+      flushSync(() => {
+        this.setState({ isApiReady: true });
+      });
 
-          // render captcha and wait for captcha id
-          this.renderCaptcha(() => {
-            // trigger onLoad if it exists
+      // render captcha and wait for captcha id
+      this.renderCaptcha(() => {
+        // trigger onLoad if it exists
 
-            const { onLoad } = this.props;
-            if (onLoad) onLoad();
-          });
+        const { onLoad } = this.props;
+        if (onLoad) onLoad();
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -46,10 +46,6 @@
     "build": "pnpm --filter=@hcaptcha-react/lib run compile:build",
     "test": "pnpm --filter=@hcaptcha-react/lib run test:unit"
   },
-  "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
-  },
   "devDependencies": {
     "@types/node": "^18.19.130",
     "@types/react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hcaptcha/react-hcaptcha",
   "description": "A React library for hCaptcha",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "hCaptcha team and contributors",
   "license": "MIT",
   "repository": {
@@ -45,6 +45,10 @@
     "start": "concurrently 'pnpm --filter=@hcaptcha-react/lib run compile:watch' 'pnpm --filter=@hcaptcha-react/demo run start'",
     "build": "pnpm --filter=@hcaptcha-react/lib run compile:build",
     "test": "pnpm --filter=@hcaptcha-react/lib run test:unit"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.130",


### PR DESCRIPTION
### Description:

This fix addressed some edge cases where integrators' React implementation might defer committing the `isApiReady` state update. Since the existing hCaptcha's rendering logic was passed as a `setState` callback, delaying the commit also delayed hCaptcha rendering and the `onLoad` callback.

By using `flushSync` we force React to commit the state update synchronously, preventing present React scheduling or batching in the integrator from deferring it. The rendering logic then runs immediately after `flushSync` preserving this way the original order: commit `isApiReady`, render hCaptcha then call `onLoad`.

### References:
https://react.dev/reference/react-dom/flushSync

